### PR TITLE
Unify returns on model setters

### DIFF
--- a/src/Manager/Blog/Blog.php
+++ b/src/Manager/Blog/Blog.php
@@ -73,10 +73,14 @@ class Blog extends Model
 
     /**
      * @param string $handle
+     *
+     * @return Blog
      */
     public function setHandle($handle)
     {
         $this->handle = $handle;
+
+        return $this;
     }
 
     /**
@@ -89,10 +93,14 @@ class Blog extends Model
 
     /**
      * @param string $title
+     *
+     * @return Blog
      */
     public function setTitle($title)
     {
         $this->title = $title;
+
+        return $this;
     }
 
     /**
@@ -105,10 +113,14 @@ class Blog extends Model
 
     /**
      * @param \DateTimeInterface $updatedAt
+     *
+     * @return Blog
      */
     public function setUpdatedAt($updatedAt)
     {
         $this->updatedAt = $updatedAt;
+
+        return $this;
     }
 
     /**
@@ -121,10 +133,14 @@ class Blog extends Model
 
     /**
      * @param string $commentable
+     *
+     * @return Blog
      */
     public function setCommentable($commentable)
     {
         $this->commentable = $commentable;
+
+        return $this;
     }
 
     /**
@@ -137,10 +153,14 @@ class Blog extends Model
 
     /**
      * @param string $feedburner
+     *
+     * @return Blog
      */
     public function setFeedburner($feedburner)
     {
         $this->feedburner = $feedburner;
+
+        return $this;
     }
 
     /**
@@ -153,10 +173,14 @@ class Blog extends Model
 
     /**
      * @param string $feedburnerLocation
+     *
+     * @return Blog
      */
     public function setFeedburnerLocation($feedburnerLocation)
     {
         $this->feedburnerLocation = $feedburnerLocation;
+
+        return $this;
     }
 
     /**
@@ -169,10 +193,14 @@ class Blog extends Model
 
     /**
      * @param \DateTimeInterface $createdAt
+     *
+     * @return Blog
      */
     public function setCreatedAt($createdAt)
     {
         $this->createdAt = $createdAt;
+
+        return $this;
     }
 
     /**
@@ -185,10 +213,14 @@ class Blog extends Model
 
     /**
      * @param string $templateSuffix
+     *
+     * @return Blog
      */
     public function setTemplateSuffix($templateSuffix)
     {
         $this->templateSuffix = $templateSuffix;
+
+        return $this;
     }
 
     /**
@@ -201,9 +233,13 @@ class Blog extends Model
 
     /**
      * @param string $tags
+     *
+     * @return Blog
      */
     public function setTags($tags)
     {
         $this->tags = $tags;
+
+        return $this;
     }
 }

--- a/src/Manager/DraftOrder/DraftOrder.php
+++ b/src/Manager/DraftOrder/DraftOrder.php
@@ -474,6 +474,8 @@ class DraftOrder extends Model
     public function setOrderId($orderId)
     {
         $this->orderId = $orderId;
+
+        return $this;
     }
 
     /**
@@ -492,6 +494,8 @@ class DraftOrder extends Model
     public function setShippingLine($shippingLine)
     {
         $this->shippingLine = $shippingLine;
+
+        return $this;
     }
 
     /**
@@ -510,6 +514,8 @@ class DraftOrder extends Model
     public function setTaxLines($taxLines)
     {
         $this->taxLines = $taxLines;
+
+        return $this;
     }
 
     /**
@@ -528,6 +534,8 @@ class DraftOrder extends Model
     public function setTag($tag)
     {
         $this->tag = $tag;
+
+        return $this;
     }
 
     /**
@@ -546,6 +554,8 @@ class DraftOrder extends Model
     public function setNoteAttributes($noteAttributes)
     {
         $this->noteAttributes = $noteAttributes;
+
+        return $this;
     }
 
     /**
@@ -564,6 +574,8 @@ class DraftOrder extends Model
     public function setTotalPrice($totalPrice)
     {
         $this->totalPrice = $totalPrice;
+
+        return $this;
     }
 
     /**

--- a/src/Manager/DraftOrder/DraftOrder.php
+++ b/src/Manager/DraftOrder/DraftOrder.php
@@ -148,10 +148,14 @@ class DraftOrder extends Model
 
     /**
      * @param string $note
+     *
+     * @return DraftOrder
      */
     public function setNote($note)
     {
         $this->note = $note;
+
+        return $this;
     }
 
     /**
@@ -164,10 +168,14 @@ class DraftOrder extends Model
 
     /**
      * @param string $email
+     *
+     * @return DraftOrder
      */
     public function setEmail($email)
     {
         $this->email = $email;
+
+        return $this;
     }
 
     /**
@@ -180,10 +188,14 @@ class DraftOrder extends Model
 
     /**
      * @param bool $taxesIncluded
+     *
+     * @return DraftOrder
      */
     public function setTaxesIncluded($taxesIncluded)
     {
         $this->taxesIncluded = $taxesIncluded;
+
+        return $this;
     }
 
     /**
@@ -196,10 +208,14 @@ class DraftOrder extends Model
 
     /**
      * @param string $currency
+     *
+     * @return DraftOrder
      */
     public function setCurrency($currency)
     {
         $this->currency = $currency;
+
+        return $this;
     }
 
     /**
@@ -212,10 +228,14 @@ class DraftOrder extends Model
 
     /**
      * @param \DateTimeInterface $invoiceSentAt
+     *
+     * @return DraftOrder
      */
     public function setInvoiceSentAt($invoiceSentAt)
     {
         $this->invoiceSentAt = $invoiceSentAt;
+
+        return $this;
     }
 
     /**
@@ -228,10 +248,14 @@ class DraftOrder extends Model
 
     /**
      * @param \DateTimeInterface $createdAt
+     *
+     * @return DraftOrder
      */
     public function setCreatedAt($createdAt)
     {
         $this->createdAt = $createdAt;
+
+        return $this;
     }
 
     /**
@@ -244,10 +268,14 @@ class DraftOrder extends Model
 
     /**
      * @param \DateTimeInterface $updatedAt
+     *
+     * @return DraftOrder
      */
     public function setUpdatedAt($updatedAt)
     {
         $this->updatedAt = $updatedAt;
+
+        return $this;
     }
 
     /**
@@ -260,10 +288,14 @@ class DraftOrder extends Model
 
     /**
      * @param bool $taxExempt
+     *
+     * @return DraftOrder
      */
     public function setTaxExempt($taxExempt)
     {
         $this->taxExempt = $taxExempt;
+
+        return $this;
     }
 
     /**
@@ -276,10 +308,14 @@ class DraftOrder extends Model
 
     /**
      * @param \DateTimeInterface $completedAt
+     *
+     * @return DraftOrder
      */
     public function setCompletedAt($completedAt)
     {
         $this->completedAt = $completedAt;
+
+        return $this;
     }
 
     /**
@@ -292,10 +328,14 @@ class DraftOrder extends Model
 
     /**
      * @param string $name
+     *
+     * @return DraftOrder
      */
     public function setName($name)
     {
         $this->name = $name;
+
+        return $this;
     }
 
     /**
@@ -308,10 +348,14 @@ class DraftOrder extends Model
 
     /**
      * @param string $status
+     *
+     * @return DraftOrder
      */
     public function setStatus($status)
     {
         $this->status = $status;
+
+        return $this;
     }
 
     /**
@@ -324,10 +368,14 @@ class DraftOrder extends Model
 
     /**
      * @param LineItem[] $lineItems
+     *
+     * @return DraftOrder
      */
     public function setLineItems($lineItems)
     {
         $this->lineItems = $lineItems;
+
+        return $this;
     }
 
     /**
@@ -340,10 +388,14 @@ class DraftOrder extends Model
 
     /**
      * @param Address $shippingAddress
+     *
+     * @return DraftOrder
      */
     public function setShippingAddress($shippingAddress)
     {
         $this->shippingAddress = $shippingAddress;
+
+        return $this;
     }
 
     /**
@@ -356,10 +408,14 @@ class DraftOrder extends Model
 
     /**
      * @param Address $billingAddress
+     *
+     * @return DraftOrder
      */
     public function setBillingAddress($billingAddress)
     {
         $this->billingAddress = $billingAddress;
+
+        return $this;
     }
 
     /**
@@ -372,10 +428,14 @@ class DraftOrder extends Model
 
     /**
      * @param string $invoiceUrl
+     *
+     * @return DraftOrder
      */
     public function setInvoiceUrl($invoiceUrl)
     {
         $this->invoiceUrl = $invoiceUrl;
+
+        return $this;
     }
 
     /**
@@ -388,10 +448,14 @@ class DraftOrder extends Model
 
     /**
      * @param array $appliedDiscount
+     *
+     * @return DraftOrder
      */
     public function setAppliedDiscount($appliedDiscount)
     {
         $this->appliedDiscount = $appliedDiscount;
+
+        return $this;
     }
 
     /**
@@ -404,6 +468,8 @@ class DraftOrder extends Model
 
     /**
      * @param int $orderId
+     *
+     * @return DraftOrder
      */
     public function setOrderId($orderId)
     {
@@ -420,6 +486,8 @@ class DraftOrder extends Model
 
     /**
      * @param array $shippingLine
+     *
+     * @return DraftOrder
      */
     public function setShippingLine($shippingLine)
     {
@@ -436,6 +504,8 @@ class DraftOrder extends Model
 
     /**
      * @param array $taxLines
+     *
+     * @return DraftOrder
      */
     public function setTaxLines($taxLines)
     {
@@ -452,6 +522,8 @@ class DraftOrder extends Model
 
     /**
      * @param string $tag
+     *
+     * @return DraftOrder
      */
     public function setTag($tag)
     {
@@ -468,6 +540,8 @@ class DraftOrder extends Model
 
     /**
      * @param string $noteAttributes
+     *
+     * @return DraftOrder
      */
     public function setNoteAttributes($noteAttributes)
     {
@@ -484,6 +558,8 @@ class DraftOrder extends Model
 
     /**
      * @param float $totalPrice
+     *
+     * @return DraftOrder
      */
     public function setTotalPrice($totalPrice)
     {
@@ -500,10 +576,14 @@ class DraftOrder extends Model
 
     /**
      * @param float $subtotalPrice
+     *
+     * @return DraftOrder
      */
     public function setSubtotalPrice($subtotalPrice)
     {
         $this->subtotalPrice = $subtotalPrice;
+
+        return $this;
     }
 
     /**
@@ -516,10 +596,14 @@ class DraftOrder extends Model
 
     /**
      * @param float $totalTax
+     *
+     * @return DraftOrder
      */
     public function setTotalTax($totalTax)
     {
         $this->totalTax = $totalTax;
+
+        return $this;
     }
 
     /**
@@ -532,9 +616,13 @@ class DraftOrder extends Model
 
     /**
      * @param Customer $customer
+     *
+     * @return DraftOrder
      */
     public function setCustomer($customer)
     {
         $this->customer = $customer;
+
+        return $this;
     }
 }

--- a/src/Manager/InventoryItem/InventoryItem.php
+++ b/src/Manager/InventoryItem/InventoryItem.php
@@ -53,7 +53,7 @@ class InventoryItem extends Model
 
     /**
      * @param string $sku
-     *                                                                
+     *
      * @return InventoryItem
      */
     public function setSku($sku)
@@ -73,7 +73,7 @@ class InventoryItem extends Model
 
     /**
      * @param float $cost
-     *                                                                
+     *
      * @return InventoryItem
      */
     public function setCost($cost)
@@ -93,7 +93,7 @@ class InventoryItem extends Model
 
     /**
      * @param bool $tracked
-     *                                                                
+     *
      * @return InventoryItem
      */
     public function setTracked($tracked)
@@ -113,7 +113,7 @@ class InventoryItem extends Model
 
     /**
      * @param string $adminGraphqlApiId
-     *                                                                
+     *
      * @return InventoryItem
      */
     public function setAdminGraphqlApiId($adminGraphqlApiId)
@@ -133,7 +133,7 @@ class InventoryItem extends Model
 
     /**
      * @param \DateTimeInterface $createdAt
-     *                                                                
+     *
      * @return InventoryItem
      */
     public function setCreatedAt($createdAt)
@@ -153,7 +153,7 @@ class InventoryItem extends Model
 
     /**
      * @param \DateTimeInterface $updatedAt
-     *                                                                
+     *
      * @return InventoryItem
      */
     public function setUpdatedAt($updatedAt)

--- a/src/Manager/InventoryLevel/InventoryLevel.php
+++ b/src/Manager/InventoryLevel/InventoryLevel.php
@@ -48,7 +48,7 @@ class InventoryLevel
 
     /**
      * @param int $inventoryItemId
-     *                                                                
+     *
      * @return InventoryLevel
      */
     public function setInventoryItemId($inventoryItemId)
@@ -68,7 +68,7 @@ class InventoryLevel
 
     /**
      * @param int $locationId
-     *                                                                
+     *
      * @return InventoryLevel
      */
     public function setLocationId($locationId)
@@ -88,7 +88,7 @@ class InventoryLevel
 
     /**
      * @param int $available
-     *                                                                
+     *
      * @return InventoryLevel
      */
     public function setAvailable($available)
@@ -108,7 +108,7 @@ class InventoryLevel
 
     /**
      * @param \DateTimeInterface $updatedAt
-     *                                                                
+     *
      * @return InventoryLevel
      */
     public function setUpdatedAt($updatedAt)
@@ -128,7 +128,7 @@ class InventoryLevel
 
     /**
      * @param string $adminGraphqlApiId
-     *                                                                
+     *
      * @return InventoryLevel
      */
     public function setAdminGraphqlApiId($adminGraphqlApiId)

--- a/src/Manager/Order/DiscountAllocation.php
+++ b/src/Manager/Order/DiscountAllocation.php
@@ -35,7 +35,7 @@ class DiscountAllocation extends Model
 
     /**
      * @param string $amount
-     *                                                                
+     *
      * @return DiscountAllocation
      */
     public function setAmount($amount)
@@ -55,7 +55,7 @@ class DiscountAllocation extends Model
 
     /**
      * @param string $discountApplicationIndex
-     *                                                                
+     *
      * @return DiscountAllocation
      */
     public function setDiscountApplicationIndex($discountApplicationIndex)

--- a/src/Manager/Order/DiscountApplication.php
+++ b/src/Manager/Order/DiscountApplication.php
@@ -60,7 +60,7 @@ class DiscountApplication extends Model
 
     /**
      * @param string $type
-     *                                                                
+     *
      * @return DiscountApplication
      */
     public function setType($type)
@@ -80,7 +80,7 @@ class DiscountApplication extends Model
 
     /**
      * @param string $value
-     *                                                                
+     *
      * @return DiscountApplication
      */
     public function setValue($value)
@@ -100,7 +100,7 @@ class DiscountApplication extends Model
 
     /**
      * @param string $valueType
-     *                                                                
+     *
      * @return DiscountApplication
      */
     public function setValueType($valueType)
@@ -120,7 +120,7 @@ class DiscountApplication extends Model
 
     /**
      * @param string $allocationMethod
-     *                                                                
+     *
      * @return DiscountApplication
      */
     public function setAllocationMethod($allocationMethod)
@@ -140,7 +140,7 @@ class DiscountApplication extends Model
 
     /**
      * @param string $targetSelection
-     *                                                                
+     *
      * @return DiscountApplication
      */
     public function setTargetSelection($targetSelection)
@@ -160,7 +160,7 @@ class DiscountApplication extends Model
 
     /**
      * @param string $targetType
-     *                                                                
+     *
      * @return DiscountApplication
      */
     public function setTargetType($targetType)
@@ -180,7 +180,7 @@ class DiscountApplication extends Model
 
     /**
      * @param string $code
-     *                                                                
+     *
      * @return DiscountApplication
      */
     public function setCode($code)

--- a/src/Manager/Order/LineItem.php
+++ b/src/Manager/Order/LineItem.php
@@ -555,7 +555,7 @@ class LineItem extends Model
 
     /**
      * @param DiscountAllocation[] $discountAllocations
-     *                                                                
+     *
      * @return LineItem
      */
     public function setDiscountAllocations($discountAllocations)

--- a/src/Manager/Order/LineItem.php
+++ b/src/Manager/Order/LineItem.php
@@ -155,10 +155,14 @@ class LineItem extends Model
 
     /**
      * @param array $appliedDiscount
+     *
+     * @return LineItem
      */
     public function setAppliedDiscount($appliedDiscount)
     {
         $this->appliedDiscount = $appliedDiscount;
+
+        return $this;
     }
 
     /**

--- a/src/Manager/Order/Order.php
+++ b/src/Manager/Order/Order.php
@@ -382,6 +382,8 @@ class Order extends Model
 
     /**
      * @param \DateTimeInterface $createdAt
+     *
+     * @return Order
      */
     public function setCreatedAt($createdAt)
     {
@@ -418,10 +420,14 @@ class Order extends Model
 
     /**
      * @param \DateTimeInterface $deletedAt
+     *
+     * @return Order
      */
     public function setDeletedAt($deletedAt)
     {
         $this->deletedAt = $deletedAt;
+
+        return $this;
     }
 
 
@@ -1555,9 +1561,13 @@ class Order extends Model
 
     /**
      * @param Customer $customer
+     *
+     * @return Order
      */
     public function setCustomer($customer)
     {
         $this->customer = $customer;
+
+        return $this;
     }
 }

--- a/src/Manager/ProductImage/Image.php
+++ b/src/Manager/ProductImage/Image.php
@@ -234,7 +234,7 @@ class Image extends Model
     /**
      * @param string $alt
      *
-     * @return string
+     * @return Image
      */
     public function setAlt($alt)
     {

--- a/src/Manager/ProductVariant/Variant.php
+++ b/src/Manager/ProductVariant/Variant.php
@@ -560,10 +560,14 @@ class Variant extends Model
 
     /**
      * @param int $inventoryItemId
+     *
+     * @return Variant
      */
     public function setInventoryItemId($inventoryItemId)
     {
         $this->inventoryItemId = $inventoryItemId;
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
### About
First of all, thank you so much for this package. It's been an absolute blast to work with. Big kudos! :heart:

Only thing I've stumbled upon so far, was a minor inconsistency with a missing return in `Variant::setInventoryItemId()`-method, not returning `$this`.

So instead of just fixing that one place, I went ahead and scanned through all `Model`-DTO's, and fixed up the return types and added any missing returns.

I was planning on writing tests for these, changes but it seems like you're testing the feature using reflection so I took the liberty to skip them. :relaxed::v:

But in either case, please don't hesitate letting me know if you want me to add the tests or if there's any particular section of the package that you would like some help with. :)

Happy monday wishes!

### Changes
- Add missing returns to Blog setters.
- Add missing returns to DraftOrder setters.
- Add missing return to LineItem setter.
- Add missing returns to Order setters.
- Fix return type of Product Image setter.
- Add missing return to Product Variant setter.
- Remove trailing in doc-blocks.
