### PR TITLE
Usage changed for private app in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ $credential = new Slince\Shopify\PrivateAppCredential('API KEY', 'PASSWORD', 'SH
 $client = new Slince\Shopify\Client('your-store.myshopify.com', $credential, [
     'meta_cache_dir' => './tmp' // Metadata cache dir, required
 ]);
+
+// Or Private App
+$client = new Slince\Shopify\Client($credential, 'your-store.myshopify.com', [
+    'metaCacheDir' => './tmp' // Metadata cache dir, required
+]);
 ```
 
 ### Middleware


### PR DESCRIPTION
While using the package for private app, I encountered that some parameters are out of order in readme file. 