### PR TITLE
3.x symfony cache

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "slince/shopify-api-php",
+    "name": "adjustmentlayer/shopify-api-php",
     "description": "Shopify API Client for PHP",
     "keywords": ["shopify", "restful", "shopify-sdk", "shopify-api", "shopify-client", "shopify-client-php"],
     "type": "library",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "adjustmentlayer/shopify-api-php",
+    "name": "slince/shopify-api-php",
     "description": "Shopify API Client for PHP",
     "keywords": ["shopify", "restful", "shopify-sdk", "shopify-api", "shopify-client", "shopify-client-php"],
     "type": "library",

--- a/composer.json
+++ b/composer.json
@@ -13,11 +13,11 @@
     "require": {
         "php": "^7.2||^8.0",
         "doctrine/inflector": "^1.2|^2.0",
-        "doctrine/cache": "^1.0",
+        "symfony/cache": "^5.0|^6.0",
         "guzzlehttp/guzzle": "^7.0",
         "slince/di": "^3.0",
         "symfony/yaml": "^4.2|^5.0|^6.0",
-        "jms/serializer": "^3.10"
+        "jms/serializer": "^3.13"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.5|^8.0|^9.0",


### PR DESCRIPTION
This PR chooses symphony/cache over doctrine/cache. I needed this because requiring symfony/cache and removing doctrine/cache fixed incompatability with oxideshop cms, mentioned in #115 